### PR TITLE
Add macOS clang support

### DIFF
--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -57,6 +57,8 @@
 # 2018-04-11, The ViaDuck Project
 # - Only generate coverage in debug mode
 #
+# 2018-06-06, Rayer
+# - Make this module compatible with most recent macOS provided Clang(AppleClang)
 #
 # USAGE:
 

--- a/CodeCoverage.cmake
+++ b/CodeCoverage.cmake
@@ -104,7 +104,7 @@ IF(NOT CMAKE_COMPILER_IS_GNUCXX)
     # Clang version 3.0.0 and greater now supports gcov as well.
     MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
 
-    IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
         MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
     ENDIF()
 ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX


### PR DESCRIPTION
Original will cause macOS can't go through code coverage because compiler name `${CMAKE_CXX_COMPILER_ID}` is AppleClang. Please accept this pull request so it can run on most recent macOS without disabling gconv functionality, thanks~