### PR TITLE
Create library target when MariaDBClient was found

### DIFF
--- a/FindMariaDBClient.cmake
+++ b/FindMariaDBClient.cmake
@@ -45,6 +45,15 @@ set(CMAKE_FIND_LIBRARY_SUFFIXES ${BAK_CMAKE_FIND_LIBRARY_SUFFIXES})
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MariaDBClient DEFAULT_MSG MariaDBClient_LIBRARY MariaDBClient_INCLUDE_DIR)
 
+if(MariaDBClient_FOUND)
+    if(NOT TARGET MariaDBClient::MariaDBClient)
+        add_library(MariaDBClient::MariaDBClient UNKNOWN IMPORTED)
+        set_target_properties(MariaDBClient::MariaDBClient PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${MariaDBClient_INCLUDE_DIR}"
+            IMPORTED_LOCATION "${MariaDBClient_LIBRARY}")
+    endif()
+endif()
+
 mark_as_advanced(MariaDBClient_INCLUDE_DIR MariaDBClient_LIBRARY)
 
 set(MariaDBClient_LIBRARIES ${MariaDBClient_LIBRARY})


### PR DESCRIPTION
This is a requirement for the modernization of the coming follow-up pull request in the `mariadbpp` repository.

In fact this makes the behaviour of the find module more conformal with the native CMake find modules, because after the package was found you can simply link against a created target:

```cmake
find_package(MariaDBClient REQUIRED)

...

target_link_libraries(
  mytarget
  PUBLIC
  MariaDBClient::MariaDBClient
)

```